### PR TITLE
Add /reset_ranks admin command

### DIFF
--- a/src/cogs/danisen.py
+++ b/src/cogs/danisen.py
@@ -805,6 +805,35 @@ class Danisen(commands.Cog):
 
         await ctx.respond(f"Configuration key `{key}` updated to `{parsed_value}`", ephemeral=True)
 
+    @discord.commands.slash_command(description="Resets danisen rank for all users (admin)")
+    @discord.commands.default_permissions(manage_guild=True)
+    async def reset_ranks(self, ctx: discord.ApplicationContext):
+        self.logger.info("Resetting ranks to Dan 1 for all users")
+
+        bot_member = ctx.guild.get_member(self.bot.user.id)
+        dan_role = discord.utils.get(ctx.guild.roles, name="Dan 1")
+
+        for member in ctx.guild.members:
+            players = self.database_cur.execute(
+                "SELECT * FROM players WHERE discord_id = ?", (member.id,)
+                ).fetchall()
+            
+            self.logger.info(f"Replacing old dan roles for users with Dan 1")
+            dan_roles_to_remove = [
+                r for r in member.roles
+                if r.name.startswith("Dan ") and r.name != "Dan 1" and self.can_manage_role(bot_member, r)]
+
+            if dan_roles_to_remove:
+                await member.remove_roles(*dan_roles_to_remove)
+
+            if players and dan_role and self.can_manage_role(bot_member, dan_role):    
+                await member.add_roles(dan_role)
+
+        self.database_cur.execute(f"UPDATE players SET dan = 1")
+        self.database_con.commit()
+
+        await ctx.respond("Danisen rank for all players reset to 1")
+
     def get_player(self, player_name, character):
         res = self.database_cur.execute(
             "SELECT * FROM players WHERE player_name=? AND character=?", 

--- a/src/cogs/danisen.py
+++ b/src/cogs/danisen.py
@@ -818,7 +818,7 @@ class Danisen(commands.Cog):
                 "SELECT * FROM players WHERE discord_id = ?", (member.id,)
                 ).fetchall()
             
-            self.logger.info(f"Replacing old dan roles for users with Dan 1")
+            self.logger.info("Replacing old dan roles for users with Dan 1")
             dan_roles_to_remove = [
                 r for r in member.roles
                 if r.name.startswith("Dan ") and r.name != "Dan 1" and self.can_manage_role(bot_member, r)]
@@ -829,7 +829,7 @@ class Danisen(commands.Cog):
             if players and dan_role and self.can_manage_role(bot_member, dan_role):    
                 await member.add_roles(dan_role)
 
-        self.database_cur.execute(f"UPDATE players SET dan = 1")
+        self.database_cur.execute("UPDATE players SET dan = 1")
         self.database_con.commit()
 
         await ctx.respond("Danisen rank for all players reset to 1")

--- a/src/cogs/danisen.py
+++ b/src/cogs/danisen.py
@@ -829,7 +829,7 @@ class Danisen(commands.Cog):
             if players and dan_role and self.can_manage_role(bot_member, dan_role):    
                 await member.add_roles(dan_role)
 
-        self.database_cur.execute("UPDATE players SET dan = 1")
+        self.database_cur.execute("UPDATE players SET dan = 1, points = 0")
         self.database_con.commit()
 
         await ctx.respond("Danisen rank for all players reset to 1")

--- a/tests/test_danisen.py
+++ b/tests/test_danisen.py
@@ -768,7 +768,7 @@ class TestDanisen(unittest.IsolatedAsyncioTestCase):
         await self.danisen.reset_ranks(self.ctx)
 
         # DB should be updated to reset all dans to 1
-        self.database_cur.execute.assert_any_call("UPDATE players SET dan = 1")
+        self.database_cur.execute.assert_any_call("UPDATE players SET dan = 1, points = 0")
         self.database_con.commit.assert_called_once()
 
         # member1 should have Dan 3 removed and Dan 1 added

--- a/tests/test_danisen.py
+++ b/tests/test_danisen.py
@@ -731,3 +731,51 @@ class TestDanisen(unittest.IsolatedAsyncioTestCase):
 
         winner_rank, loser_rank = await self.danisen.score_update(self.ctx, winner, loser)
         self.assertEqual(winner_rank, [9, 0], "High-rank player should rank up normally when special rules are disabled")
+
+    async def test_reset_ranks_resets_db_and_roles(self):
+        """Test that reset_ranks resets all players to Dan 1 and updates Discord roles."""
+        bot_member = MagicMock()
+        bot_member.top_role.position = 10
+        bot_member.guild_permissions.manage_roles = True
+
+        dan1_role = MagicMock()
+        dan1_role.name = "Dan 1"
+        dan1_role.position = 1
+
+        dan3_role = MagicMock()
+        dan3_role.name = "Dan 3"
+        dan3_role.position = 3
+
+        member1 = AsyncMock()
+        member1.id = 12345
+        member1.roles = [dan3_role]
+
+        member2 = AsyncMock()
+        member2.id = 67890
+        member2.roles = []
+
+        self.ctx.guild = MagicMock()
+        self.ctx.guild.members = [member1, member2]
+        self.ctx.guild.get_member = MagicMock(return_value=bot_member)
+        self.ctx.guild.roles = [dan1_role, dan3_role]
+
+        self.database_cur.execute.return_value = self.database_cur
+        self.database_cur.fetchall.side_effect = [
+            [{"discord_id": 12345, "character": "Hyde", "dan": 3, "points": 2}],  # member1 players
+            []  # member2 players (not registered)
+        ]
+
+        await self.danisen.reset_ranks(self.ctx)
+
+        # DB should be updated to reset all dans to 1
+        self.database_cur.execute.assert_any_call("UPDATE players SET dan = 1")
+        self.database_con.commit.assert_called_once()
+
+        # member1 should have Dan 3 removed and Dan 1 added
+        member1.remove_roles.assert_called_once_with(dan3_role)
+        member1.add_roles.assert_called_once_with(dan1_role)
+
+        # member2 has no registered players, so no roles added
+        member2.add_roles.assert_not_called()
+
+        self.ctx.respond.assert_called_with("Danisen rank for all players reset to 1")


### PR DESCRIPTION
- Adds a new admin-only slash command /reset_ranks that resets all registered players' dan back to Dan 1 in the database
- Removes any existing Dan roles (Dan 2+) from every server member and assigns the Dan 1 role
- Respects bot role hierarchy — only removes/adds roles the bot has permission to manage
- DB update is deferred until after Discord role changes so role lookups reflect pre-reset state